### PR TITLE
fix-finder: update to v114 and new image

### DIFF
--- a/compiler-fix-finder-agent/README.md
+++ b/compiler-fix-finder-agent/README.md
@@ -150,7 +150,7 @@ spec:
   chart:
     repository: oci://icr.io/zoscp/ibm-z-compilers-fix-finder
     name: compiler-fix-finder-agent
-    version: "1.1.3"  # Update to the desired chart version
+    version: "1.1.4"  # Update to the desired chart version
     pullSecrets: # pullSecrets is used to pull image from registry
       - name: z-compiler-fix-finder-image-pull-secret
 

--- a/compiler-fix-finder-agent/cr.yaml
+++ b/compiler-fix-finder-agent/cr.yaml
@@ -24,7 +24,7 @@ spec:
   chart:
     name: compiler-fix-finder-agent # name of the helm chart
     repository: oci://icr.io/zoscp/ibm-z-compilers-fix-finder # OCI registry namespace where the helm chart is stored
-    version: "1.1.3" # version of the helm chart
+    version: "1.1.4" # version of the helm chart
     pullSecrets: # pullSecrets is used to pull image from registry
       - name: z-compiler-fix-finder-image-pull-secret
   values:


### PR DESCRIPTION
## fix-finder: update to v114 and new image

Compiler-fix-finder agent needed to have a new image build because of found various security violations.
That caused also our compiler-fix-finder release to move from `1.1.3` to `1.1.4`

New HELM charts were created based on these changes and pushed to production:
```
$ helm package agent-helm-charts/compiler-fix-finder-agent
$ helm push compiler-fix-finder-agent-1.1.4.tgz oci://icr.io/zoscp/ibm-z-compilers-fix-finder
	Pushed: icr.io/zoscp/ibm-z-compilers-fix-finder/compiler-fix-finder-agent:1.1.4
	Digest: sha256:b1b3354872ecdbbfa130890bd9aaf00e75afae6f65452e4cd132b5d643afc117
```

The new image was moved from the sandbox
```
    "Name": "icr.io/zoscp-sandbox/ibm-z-compilers-fix-finder-agent",
    "Digest": "sha256:34e89753d2093f34e5c93ec9a30f908fb721130ab7b93fb32d2a1bd8f4884cb2",
```
to the production:
```
    "Name": "icr.io/zoscp/ibm-z-compilers-fix-finder-agent",
    "Digest": "sha256:34e89753d2093f34e5c93ec9a30f908fb721130ab7b93fb32d2a1bd8f4884cb2"
```

_Note:_ PR [ix-finder: update to v114 and new image #601](https://github.ibm.com/wxa4z/agent-deployment-charts/pull/601) was made to update wxa4z charts

This PR is to update the agent version for its HEL charts
